### PR TITLE
Adjust the coordinates on which the camera focuses on smaller screens

### DIFF
--- a/opensrp-reveal/src/main/java/org/smartregister/reveal/presenter/ListTaskPresenter.java
+++ b/opensrp-reveal/src/main/java/org/smartregister/reveal/presenter/ListTaskPresenter.java
@@ -379,8 +379,8 @@ public class ListTaskPresenter implements ListTaskContract.PresenterCallBack {
     }
 
     private void formatCardDetails(CardDetails cardDetails) {
-        // format date
         try {
+            // format date
             DateFormat sdf = new SimpleDateFormat(EVENT_DATE_FORMAT, Locale.getDefault());
             Date originalDate = sdf.parse(cardDetails.getSprayDate());
 

--- a/opensrp-reveal/src/main/java/org/smartregister/reveal/presenter/ListTaskPresenter.java
+++ b/opensrp-reveal/src/main/java/org/smartregister/reveal/presenter/ListTaskPresenter.java
@@ -32,13 +32,9 @@ import org.smartregister.reveal.util.PreferencesUtil;
 import org.smartregister.util.AssetHandler;
 import org.smartregister.util.Utils;
 
-import java.text.DateFormat;
-import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Date;
 import java.util.List;
-import java.util.Locale;
 
 import static org.smartregister.AllConstants.OPERATIONAL_AREAS;
 import static org.smartregister.reveal.contract.ListTaskContract.ListTaskView;
@@ -47,8 +43,8 @@ import static org.smartregister.reveal.util.Constants.BusinessStatus.NOT_SPRAYED
 import static org.smartregister.reveal.util.Constants.BusinessStatus.NOT_VISITED;
 import static org.smartregister.reveal.util.Constants.BusinessStatus.SPRAYED;
 import static org.smartregister.reveal.util.Constants.DETAILS;
-import static org.smartregister.reveal.util.Constants.DateFormat.CARD_VIEW_DATE_FORMAT;
-import static org.smartregister.reveal.util.Constants.DateFormat.EVENT_DATE_FORMAT;
+import static org.smartregister.reveal.util.Constants.DateFormat.EVENT_DATE_FORMAT_XXX;
+import static org.smartregister.reveal.util.Constants.DateFormat.EVENT_DATE_FORMAT_Z;
 import static org.smartregister.reveal.util.Constants.ENTITY_ID;
 import static org.smartregister.reveal.util.Constants.GeoJSON.FEATURES;
 import static org.smartregister.reveal.util.Constants.Intervention.IRS;
@@ -73,6 +69,7 @@ import static org.smartregister.reveal.util.Constants.Tags.DISTRICT;
 import static org.smartregister.reveal.util.Constants.Tags.HEALTH_CENTER;
 import static org.smartregister.reveal.util.Constants.Tags.OPERATIONAL_AREA;
 import static org.smartregister.reveal.util.Constants.Tags.PROVINCE;
+import static org.smartregister.reveal.util.Utils.formatDate;
 import static org.smartregister.reveal.util.Utils.getPropertyValue;
 
 /**
@@ -381,15 +378,20 @@ public class ListTaskPresenter implements ListTaskContract.PresenterCallBack {
     private void formatCardDetails(CardDetails cardDetails) {
         try {
             // format date
-            DateFormat sdf = new SimpleDateFormat(EVENT_DATE_FORMAT, Locale.getDefault());
-            Date originalDate = sdf.parse(cardDetails.getSprayDate());
-
-            sdf = new SimpleDateFormat(CARD_VIEW_DATE_FORMAT, Locale.getDefault());
-            String formattedDate = sdf.format(originalDate);
+            String formattedDate = formatDate(cardDetails.getSprayDate(), EVENT_DATE_FORMAT_Z);
             cardDetails.setSprayDate(formattedDate);
         } catch (Exception e) {
             Log.e(TAG, e.getMessage());
+            Log.i(TAG, "Date parsing failed, trying another date format");
+            try {
+                // try another date format
+                String formattedDate = formatDate(cardDetails.getSprayDate(), EVENT_DATE_FORMAT_XXX);
+                cardDetails.setSprayDate(formattedDate);
+            } catch (Exception exception) {
+                Log.e(TAG, exception.getMessage());
+            }
         }
+
         // extract status color
         String sprayStatus = cardDetails.getSprayStatus();
         if (NOT_SPRAYED.equals(sprayStatus)) {

--- a/opensrp-reveal/src/main/java/org/smartregister/reveal/util/Constants.java
+++ b/opensrp-reveal/src/main/java/org/smartregister/reveal/util/Constants.java
@@ -111,10 +111,12 @@ public interface Constants {
     }
 
     interface DateFormat {
-        String EVENT_DATE_FORMAT = "yyyy-MM-dd'T'HH:mm:ss.SSSXXX";
+
+        String EVENT_DATE_FORMAT_Z = "yyyy-MM-dd'T'HH:mm:ss.SSSZ";
+
+        String EVENT_DATE_FORMAT_XXX = "yyyy-MM-dd'T'HH:mm:ss.SSSXXX";
 
         String CARD_VIEW_DATE_FORMAT = "dd MMM yyyy";
     }
-
 
 }

--- a/opensrp-reveal/src/main/java/org/smartregister/reveal/util/Utils.java
+++ b/opensrp-reveal/src/main/java/org/smartregister/reveal/util/Utils.java
@@ -20,8 +20,13 @@ import org.smartregister.reveal.R;
 import org.smartregister.reveal.application.RevealApplication;
 import org.smartregister.reveal.job.RevealCampaignServiceJob;
 
+import java.text.DateFormat;
+import java.text.SimpleDateFormat;
 import java.util.ArrayList;
+import java.util.Date;
 import java.util.Locale;
+
+import static org.smartregister.reveal.util.Constants.DateFormat.CARD_VIEW_DATE_FORMAT;
 
 public class Utils {
 
@@ -75,4 +80,12 @@ public class Utils {
         RevealCampaignServiceJob.scheduleJobImmediately(RevealCampaignServiceJob.TAG);
     }
 
+    public static String formatDate(String date, String dateFormat) throws Exception {
+        DateFormat sdf = new SimpleDateFormat(dateFormat);
+        Date originalDate = sdf.parse(date);
+
+        sdf = new SimpleDateFormat(CARD_VIEW_DATE_FORMAT);
+
+        return  sdf.format(originalDate);
+    }
 }

--- a/opensrp-reveal/src/main/java/org/smartregister/reveal/view/ListTasksActivity.java
+++ b/opensrp-reveal/src/main/java/org/smartregister/reveal/view/ListTasksActivity.java
@@ -5,6 +5,7 @@ import android.content.Context;
 import android.content.DialogInterface;
 import android.content.Intent;
 import android.content.pm.PackageManager;
+import android.content.res.Configuration;
 import android.os.Bundle;
 import android.support.annotation.NonNull;
 import android.support.annotation.StringRes;
@@ -385,9 +386,18 @@ public class ListTasksActivity extends BaseMapActivity implements ListTaskContra
 
     @Override
     public void displaySelectedFeature(Feature feature, LatLng point) {
+        adjustFocusPoint(point);
         kujakuMapView.centerMap(point, ANIMATE_TO_LOCATION_DURATION, mMapboxMap.getCameraPosition().zoom);
         if (selectedGeoJsonSource != null) {
             selectedGeoJsonSource.setGeoJson(FeatureCollection.fromFeature(feature));
+        }
+    }
+
+    private void adjustFocusPoint(LatLng point) {
+        final double VERTICAL_OFFSET = -0.0003;
+        int screenSize = getResources().getConfiguration().screenLayout & Configuration.SCREENLAYOUT_SIZE_MASK;
+        if (screenSize == Configuration.SCREENLAYOUT_SIZE_NORMAL || screenSize == Configuration.SCREENLAYOUT_SIZE_SMALL) {
+           point.setLatitude(point.getLatitude() + VERTICAL_OFFSET);
         }
     }
 


### PR DESCRIPTION
The default behavior is that the camera focuses on the clicked feature point and centers it on the screen.

A small vertical offset is required on smaller screens to prevent the focus feature point from being obstructed by the card view that appears after a feature point is clicked.