### PR TITLE
Re-Client process Events

### DIFF
--- a/opensrp-reveal/build.gradle
+++ b/opensrp-reveal/build.gradle
@@ -176,7 +176,7 @@ dependencies {
 
     implementation 'io.ona.kujaku:utils:0.5.5'
 
-    implementation('org.smartregister:opensrp-client-core:1.5.14-SNAPSHOT@aar') {
+    implementation('org.smartregister:opensrp-client-core:1.5.15-SNAPSHOT@aar') {
         transitive = true
         exclude group: 'com.github.bmelnychuk', module: 'atv'
         exclude group: 'com.google.guava', module: 'guava'

--- a/opensrp-reveal/src/main/java/org/smartregister/reveal/sync/LocationTaskIntentService.java
+++ b/opensrp-reveal/src/main/java/org/smartregister/reveal/sync/LocationTaskIntentService.java
@@ -48,6 +48,11 @@ public class LocationTaskIntentService extends IntentService {
 
         Pair<Boolean, Set<String>> structureIds = checkChangeInOperationalAreaAndExtractStructureIds(syncedStructures, synchedTasks);
 
+        if (structureIds.first != null && structureIds.first) {
+            Intent intent = new Intent(STRUCTURE_TASK_SYNCHED);
+            LocalBroadcastManager.getInstance(getApplicationContext()).sendBroadcast(intent);
+        }
+
         clientProcessEvents(structureIds.second);
 
         new AppExecutors().mainThread().execute(new Runnable() {
@@ -57,10 +62,6 @@ public class LocationTaskIntentService extends IntentService {
             }
         });
 
-        if (structureIds.first != null && structureIds.first) {
-            Intent intent = new Intent(STRUCTURE_TASK_SYNCHED);
-            LocalBroadcastManager.getInstance(getApplicationContext()).sendBroadcast(intent);
-        }
     }
 
     private Pair<Boolean, Set<String>> checkChangeInOperationalAreaAndExtractStructureIds(List<Location> syncedStructures, List<Task> synchedTasks) {

--- a/opensrp-reveal/src/main/java/org/smartregister/reveal/sync/LocationTaskIntentService.java
+++ b/opensrp-reveal/src/main/java/org/smartregister/reveal/sync/LocationTaskIntentService.java
@@ -4,7 +4,6 @@ import android.app.IntentService;
 import android.content.Intent;
 import android.support.annotation.Nullable;
 import android.support.v4.content.LocalBroadcastManager;
-import android.support.v4.util.Pair;
 
 import org.smartregister.domain.Location;
 import org.smartregister.domain.Task;

--- a/opensrp-reveal/src/main/java/org/smartregister/reveal/sync/LocationTaskIntentService.java
+++ b/opensrp-reveal/src/main/java/org/smartregister/reveal/sync/LocationTaskIntentService.java
@@ -2,19 +2,28 @@ package org.smartregister.reveal.sync;
 
 import android.app.IntentService;
 import android.content.Intent;
+import android.os.Handler;
+import android.os.Looper;
 import android.support.annotation.Nullable;
 import android.support.v4.content.LocalBroadcastManager;
+import android.support.v4.util.Pair;
 
 import org.smartregister.domain.Location;
 import org.smartregister.domain.Task;
+import org.smartregister.domain.db.EventClient;
 import org.smartregister.job.SyncServiceJob;
-import org.smartregister.reveal.util.AppExecutors;
+import org.smartregister.repository.BaseRepository;
+import org.smartregister.repository.EventClientRepository;
+import org.smartregister.reveal.application.RevealApplication;
 import org.smartregister.reveal.util.PreferencesUtil;
 import org.smartregister.reveal.util.Utils;
 import org.smartregister.sync.helper.LocationServiceHelper;
 import org.smartregister.sync.helper.TaskServiceHelper;
 
+import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 import static org.smartregister.reveal.util.Constants.Action.STRUCTURE_TASK_SYNCHED;
 
@@ -38,43 +47,53 @@ public class LocationTaskIntentService extends IntentService {
         List<Location> syncedStructures = locationServiceHelper.fetchLocationsStructures();
         List<Task> synchedTasks = taskServiceHelper.syncTasks();
 
-        (new AppExecutors()).mainThread().execute(new Runnable() {
-            @Override
-            public void run() {
-                SyncServiceJob.scheduleJobImmediately(SyncServiceJob.TAG);
-            }
-        });
-
-        if (hasChangesInCurrentOperationalArea(syncedStructures, synchedTasks)) {
+        Pair<Boolean, Set<String>> structureIds = checkChangeInOperationalAreaAndExtractStructureIds(syncedStructures, synchedTasks);
+        if (structureIds.first != null && structureIds.first) {
             Intent intent = new Intent(STRUCTURE_TASK_SYNCHED);
             LocalBroadcastManager.getInstance(getApplicationContext()).sendBroadcast(intent);
         }
 
+        clientProcessEvents(structureIds.second);
+
+        new Handler(Looper.getMainLooper()).postDelayed(new Runnable() {
+            @Override
+            public void run() {
+                SyncServiceJob.scheduleJobImmediately(SyncServiceJob.TAG);
+            }
+        }, 2000);
     }
 
-    private boolean hasChangesInCurrentOperationalArea(List<Location> syncedStructures, List<Task> synchedTasks) {
+    private Pair<Boolean, Set<String>> checkChangeInOperationalAreaAndExtractStructureIds(List<Location> syncedStructures, List<Task> synchedTasks) {
         Location operationalAreaLocation = Utils.getOperationalAreaLocation(PreferencesUtil.getInstance().getCurrentOperationalArea());
-        String operationalAreaLocationId;
-        if (operationalAreaLocation == null) {
-            return false;
-        } else {
-            operationalAreaLocationId = operationalAreaLocation.getId();
-        }
+        String operationalAreaLocationId = operationalAreaLocation == null ? null : operationalAreaLocation.getId();
+        Set<String> structureIds = new HashSet<>();
+        boolean hasChangeInOperationalArea = false;
         if (syncedStructures != null) {
             for (Location structure : syncedStructures) {
-                if (operationalAreaLocationId.equals(structure.getProperties().getParentId())) {
-                    return true;
+                if (!hasChangeInOperationalArea && operationalAreaLocationId != null && operationalAreaLocationId.equals(structure.getProperties().getParentId())) {
+                    hasChangeInOperationalArea = true;
                 }
+                structureIds.add(structure.getId());
             }
         }
         if (synchedTasks != null) {
             for (Task task : synchedTasks) {
-                if (operationalAreaLocationId.equals(task.getGroupIdentifier())) {
-                    return true;
+                if (!hasChangeInOperationalArea && operationalAreaLocationId != null && operationalAreaLocationId.equals(task.getGroupIdentifier())) {
+                    hasChangeInOperationalArea = true;
                 }
+                structureIds.add(task.getForEntity());
             }
         }
-        return false;
+        return new Pair<>(hasChangeInOperationalArea, structureIds);
+    }
+
+    private void clientProcessEvents(Set<String> syncedStructuresIds) {
+
+        EventClientRepository ecRepository = RevealApplication.getInstance().getContext().getEventClientRepository();
+        List<EventClient> eventClients = ecRepository.getEventsByBaseEntityIdsAndSyncStatus(BaseRepository.TYPE_Task_Unprocessed, new ArrayList<>(syncedStructuresIds));
+        if (!eventClients.isEmpty()) {
+            RevealClientProcessor.getInstance(getApplicationContext()).processClient(eventClients);
+        }
     }
 
 }

--- a/opensrp-reveal/src/main/java/org/smartregister/reveal/sync/RevealClientProcessor.java
+++ b/opensrp-reveal/src/main/java/org/smartregister/reveal/sync/RevealClientProcessor.java
@@ -12,6 +12,7 @@ import org.smartregister.domain.db.Event;
 import org.smartregister.domain.db.EventClient;
 import org.smartregister.domain.jsonmapping.ClientClassification;
 import org.smartregister.repository.BaseRepository;
+import org.smartregister.repository.EventClientRepository;
 import org.smartregister.reveal.application.RevealApplication;
 import org.smartregister.reveal.util.Constants.JsonForm;
 import org.smartregister.reveal.util.PreferencesUtil;
@@ -105,6 +106,7 @@ public class RevealClientProcessor extends ClientProcessorForJava {
         if (event.getDetails() != null && event.getDetails().get(TASK_IDENTIFIER) != null) {
             String taskIdentifier = event.getDetails().get(TASK_IDENTIFIER);
             Task task = RevealApplication.getInstance().getTaskRepository().getTaskByIdentifier(taskIdentifier);
+            EventClientRepository eventClientRepository = RevealApplication.getInstance().getContext().getEventClientRepository();
             if (task != null) {
                 task.setBusinessStatus(calculateBusinessStatus(event));
                 task.setStatus(Task.TaskStatus.COMPLETED);
@@ -112,10 +114,10 @@ public class RevealClientProcessor extends ClientProcessorForJava {
                     task.setSyncStatus(BaseRepository.TYPE_Unsynced);
                 }
                 RevealApplication.getInstance().getTaskRepository().addOrUpdate(task);
-                RevealApplication.getInstance().getContext().getEventClientRepository().markEventAsSynced(event.getFormSubmissionId());
+                eventClientRepository.markEventAsSynced(event.getFormSubmissionId());
                 operationalAreaId = task.getGroupIdentifier();
             } else {
-                RevealApplication.getInstance().getContext().getEventClientRepository().updateTaskUnprocessedEventStatus(event.getFormSubmissionId());
+                eventClientRepository.markEventAsTaskUnprocessed(event.getFormSubmissionId());
             }
             Location structure = RevealApplication.getInstance().getStructureRepository().getLocationById(event.getBaseEntityId());
             if (structure != null) {

--- a/opensrp-reveal/src/main/java/org/smartregister/reveal/sync/RevealClientProcessor.java
+++ b/opensrp-reveal/src/main/java/org/smartregister/reveal/sync/RevealClientProcessor.java
@@ -1,6 +1,5 @@
 package org.smartregister.reveal.sync;
 
-import android.app.usage.UsageEvents;
 import android.content.Context;
 import android.util.Log;
 
@@ -16,7 +15,6 @@ import org.smartregister.reveal.application.RevealApplication;
 import org.smartregister.reveal.util.Constants.JsonForm;
 import org.smartregister.sync.ClientProcessorForJava;
 
-import java.security.PrivateKey;
 import java.util.List;
 
 import static org.smartregister.reveal.util.Constants.BusinessStatus.NOT_SPRAYABLE;

--- a/opensrp-reveal/src/main/java/org/smartregister/reveal/sync/RevealClientProcessor.java
+++ b/opensrp-reveal/src/main/java/org/smartregister/reveal/sync/RevealClientProcessor.java
@@ -111,9 +111,9 @@ public class RevealClientProcessor extends ClientProcessorForJava {
                     task.setSyncStatus(BaseRepository.TYPE_Unsynced);
                 }
                 RevealApplication.getInstance().getTaskRepository().addOrUpdate(task);
-                RevealApplication.getInstance().getContext().getEventClientRepository().updateTaskUnprocessedEventStatus(event.getFormSubmissionId(), true);
-            }else {
-                RevealApplication.getInstance().getContext().getEventClientRepository().updateTaskUnprocessedEventStatus(event.getFormSubmissionId(), false);
+                RevealApplication.getInstance().getContext().getEventClientRepository().markEventAsSynced(event.getFormSubmissionId());
+            } else {
+                RevealApplication.getInstance().getContext().getEventClientRepository().updateTaskUnprocessedEventStatus(event.getFormSubmissionId());
             }
             Location structure = RevealApplication.getInstance().getStructureRepository().getLocationById(event.getBaseEntityId());
             if (structure != null) {

--- a/opensrp-reveal/src/main/java/org/smartregister/reveal/sync/RevealClientProcessor.java
+++ b/opensrp-reveal/src/main/java/org/smartregister/reveal/sync/RevealClientProcessor.java
@@ -147,4 +147,9 @@ public class RevealClientProcessor extends ClientProcessorForJava {
             return sprayStatus;
         }
     }
+
+    @Override
+    public void updateClientDetailsTable(Event event, Client client) {
+        //do nothing
+    }
 }

--- a/opensrp-reveal/src/main/java/org/smartregister/reveal/util/RevealSyncConfiguration.java
+++ b/opensrp-reveal/src/main/java/org/smartregister/reveal/util/RevealSyncConfiguration.java
@@ -41,4 +41,9 @@ public class RevealSyncConfiguration extends SyncConfiguration {
     public int getUniqueIdInitialBatchSize() {
         return BuildConfig.OPENMRS_UNIQUE_ID_INITIAL_BATCH_SIZE;
     }
+
+    @Override
+    public boolean isSyncSettings(){
+        return false;
+    }
 }


### PR DESCRIPTION
PR for Issue [https://github.com/OpenSRP/opensrp-client-reveal/issues/49](https://github.com/OpenSRP/opensrp-client-reveal/issues/49)

Depends on PR [https://github.com/OpenSRP/opensrp-client-core/pull/150](https://github.com/OpenSRP/opensrp-client-core/pull/150)

- Fixes refreshing geowidget if a spray event is synched in the current selected operational area
- Disables updating the ec_details fts table as no queries are run against the table