### PR TITLE
Fix Namibia app crashing on upgrade to db version 5

### DIFF
--- a/opensrp-reveal/src/main/assets/ec_client_fields_namibia.json
+++ b/opensrp-reveal/src/main/assets/ec_client_fields_namibia.json
@@ -568,6 +568,46 @@
           }
         }
       ]
+    },
+    {
+      "name": "event_task",
+      "columns": [
+        {
+          "column_name": "base_entity_id",
+          "type": "Event",
+          "json_mapping": {
+            "field": "formSubmissionId"
+          }
+        },
+        {
+          "column_name": "task_entity_id",
+          "type": "Event",
+          "json_mapping": {
+            "field": "baseEntityId"
+          }
+        },
+        {
+          "column_name": "event_id",
+          "type": "Event",
+          "json_mapping": {
+            "field": "id"
+          }
+        },
+        {
+          "column_name": "task_id",
+          "type": "Event",
+          "json_mapping": {
+            "field": "details.taskIdentifier"
+          }
+        },
+        {
+          "column_name": "event_date",
+          "type": "Event",
+          "json_mapping": {
+            "field": "eventDate"
+          }
+        }
+      ]
     }
   ]
 }

--- a/opensrp-reveal/src/main/assets/ec_client_fields_namibia.json
+++ b/opensrp-reveal/src/main/assets/ec_client_fields_namibia.json
@@ -568,46 +568,6 @@
           }
         }
       ]
-    },
-    {
-      "name": "event_task",
-      "columns": [
-        {
-          "column_name": "base_entity_id",
-          "type": "Event",
-          "json_mapping": {
-            "field": "formSubmissionId"
-          }
-        },
-        {
-          "column_name": "task_entity_id",
-          "type": "Event",
-          "json_mapping": {
-            "field": "baseEntityId"
-          }
-        },
-        {
-          "column_name": "event_id",
-          "type": "Event",
-          "json_mapping": {
-            "field": "id"
-          }
-        },
-        {
-          "column_name": "task_id",
-          "type": "Event",
-          "json_mapping": {
-            "field": "details.taskIdentifier"
-          }
-        },
-        {
-          "column_name": "event_date",
-          "type": "Event",
-          "json_mapping": {
-            "field": "eventDate"
-          }
-        }
-      ]
     }
   ]
 }

--- a/opensrp-reveal/src/main/java/org/smartregister/reveal/repository/RevealRepository.java
+++ b/opensrp-reveal/src/main/java/org/smartregister/reveal/repository/RevealRepository.java
@@ -23,6 +23,7 @@ import org.smartregister.reveal.BuildConfig;
 import org.smartregister.reveal.application.RevealApplication;
 import org.smartregister.reveal.sync.RevealClientProcessor;
 import org.smartregister.reveal.util.Constants.DatabaseKeys;
+import org.smartregister.reveal.util.Country;
 import org.smartregister.reveal.util.FamilyConstants.EventType;
 import org.smartregister.reveal.util.Utils;
 import org.smartregister.util.DatabaseMigrationUtils;
@@ -188,7 +189,7 @@ public class RevealRepository extends Repository {
     }
 
     private void upgradeToVersion5(SQLiteDatabase db) {
-        if (!isColumnExists(db, EVENT_TASK_TABLE, DatabaseKeys.PERSON_TESTED)) {
+        if (BuildConfig.BUILD_COUNTRY == Country.THAILAND && !isColumnExists(db, EVENT_TASK_TABLE, DatabaseKeys.PERSON_TESTED)) {
             db.execSQL(String.format("ALTER TABLE %s ADD COLUMN %s VARCHAR ", EVENT_TASK_TABLE, DatabaseKeys.PERSON_TESTED));
         }
     }


### PR DESCRIPTION
The Namibia app is crashing during login  due to missing `event_task` table that is required when upgrading to database version 5.