### PR TITLE
Add initial form version

### DIFF
--- a/opensrp-reveal/src/main/assets/json.form/add_structure.json
+++ b/opensrp-reveal/src/main/assets/json.form/add_structure.json
@@ -1,6 +1,7 @@
 {
   "count": "1",
   "encounter_type": "Register_Structure",
+  "form_version": "0.0.1",
   "entity_id": "",
   "metadata": {
     "start": {

--- a/opensrp-reveal/src/main/assets/json.form/bednet_distribution.json
+++ b/opensrp-reveal/src/main/assets/json.form/bednet_distribution.json
@@ -1,6 +1,7 @@
 {
   "count": "1",
   "encounter_type": "bednet_distribution",
+  "form_version": "0.0.1",
   "entity_id": "",
   "metadata": {
     "start": {

--- a/opensrp-reveal/src/main/assets/json.form/behaviour_change_communication.json
+++ b/opensrp-reveal/src/main/assets/json.form/behaviour_change_communication.json
@@ -1,6 +1,7 @@
 {
   "count": "1",
   "encounter_type": "behaviour_change_communication",
+  "form_version": "0.0.1",
   "entity_id": "",
   "metadata": {
     "start": {

--- a/opensrp-reveal/src/main/assets/json.form/botswana_spray_form.json
+++ b/opensrp-reveal/src/main/assets/json.form/botswana_spray_form.json
@@ -1,6 +1,7 @@
 {
   "count": "1",
   "encounter_type": "Spray",
+  "form_version": "0.0.1",
   "entity_id": "",
   "metadata": {
     "start": {

--- a/opensrp-reveal/src/main/assets/json.form/case_confirmation.json
+++ b/opensrp-reveal/src/main/assets/json.form/case_confirmation.json
@@ -1,6 +1,7 @@
 {
   "count": "1",
   "encounter_type": "case_confirmation",
+  "form_version": "0.0.1",
   "entity_id": "",
   "metadata": {
     "start": {

--- a/opensrp-reveal/src/main/assets/json.form/family_member_register.json
+++ b/opensrp-reveal/src/main/assets/json.form/family_member_register.json
@@ -1,6 +1,7 @@
 {
   "count": "1",
   "encounter_type": "Family Member Registration",
+  "form_version": "0.0.1",
   "entity_id": "",
   "relational_id": "",
   "metadata": {

--- a/opensrp-reveal/src/main/assets/json.form/family_register.json
+++ b/opensrp-reveal/src/main/assets/json.form/family_register.json
@@ -1,6 +1,7 @@
 {
   "count": "2",
   "encounter_type": "Family Registration",
+  "form_version": "0.0.1",
   "entity_id": "",
   "relational_id": "",
   "metadata": {

--- a/opensrp-reveal/src/main/assets/json.form/family_update.json
+++ b/opensrp-reveal/src/main/assets/json.form/family_update.json
@@ -1,6 +1,7 @@
 {
   "count": "2",
   "encounter_type": "Family Registration",
+  "form_version": "0.0.1",
   "entity_id": "",
   "relational_id": "",
   "metadata": {

--- a/opensrp-reveal/src/main/assets/json.form/larval_dipping_form.json
+++ b/opensrp-reveal/src/main/assets/json.form/larval_dipping_form.json
@@ -1,6 +1,7 @@
 {
   "count": "1",
   "encounter_type": "larval_dipping",
+  "form_version": "0.0.1",
   "entity_id": "",
   "metadata": {
     "start": {

--- a/opensrp-reveal/src/main/assets/json.form/mosquito_collection_form.json
+++ b/opensrp-reveal/src/main/assets/json.form/mosquito_collection_form.json
@@ -1,6 +1,7 @@
 {
   "count": "1",
   "encounter_type": "mosquito_collection",
+  "form_version": "0.0.1",
   "entity_id": "",
   "metadata": {
     "start": {

--- a/opensrp-reveal/src/main/assets/json.form/namibia_add_structure.json
+++ b/opensrp-reveal/src/main/assets/json.form/namibia_add_structure.json
@@ -1,6 +1,7 @@
 {
   "count": "1",
   "encounter_type": "Register_Structure",
+  "form_version": "0.0.1",
   "entity_id": "",
   "metadata": {
     "start": {

--- a/opensrp-reveal/src/main/assets/json.form/namibia_spray_form.json
+++ b/opensrp-reveal/src/main/assets/json.form/namibia_spray_form.json
@@ -1,6 +1,7 @@
 {
   "count": "1",
   "encounter_type": "Spray",
+  "form_version": "0.0.1",
   "entity_id": "",
   "metadata": {
     "start": {

--- a/opensrp-reveal/src/main/assets/json.form/paot.json
+++ b/opensrp-reveal/src/main/assets/json.form/paot.json
@@ -1,6 +1,7 @@
 {
   "count": "1",
   "encounter_type": "PAOT",
+  "form_version": "0.0.1",
   "entity_id": "",
   "metadata": {
     "start": {

--- a/opensrp-reveal/src/main/assets/json.form/refapp_bednet_distribution.json
+++ b/opensrp-reveal/src/main/assets/json.form/refapp_bednet_distribution.json
@@ -1,6 +1,7 @@
 {
   "count": "1",
   "encounter_type": "bednet_distribution",
+  "form_version": "0.0.1",
   "entity_id": "",
   "metadata": {
     "start": {

--- a/opensrp-reveal/src/main/assets/json.form/refapp_case_confirmation.json
+++ b/opensrp-reveal/src/main/assets/json.form/refapp_case_confirmation.json
@@ -1,6 +1,7 @@
 {
   "count": "1",
   "encounter_type": "case_confirmation",
+  "form_version": "0.0.1",
   "entity_id": "",
   "metadata": {
     "start": {

--- a/opensrp-reveal/src/main/assets/json.form/refapp_family_member_register.json
+++ b/opensrp-reveal/src/main/assets/json.form/refapp_family_member_register.json
@@ -1,6 +1,7 @@
 {
   "count": "1",
   "encounter_type": "Family Member Registration",
+  "form_version": "0.0.1",
   "entity_id": "",
   "relational_id": "",
   "metadata": {

--- a/opensrp-reveal/src/main/assets/json.form/refapp_family_register.json
+++ b/opensrp-reveal/src/main/assets/json.form/refapp_family_register.json
@@ -1,6 +1,7 @@
 {
   "count": "2",
   "encounter_type": "Family Registration",
+  "form_version": "0.0.1",
   "entity_id": "",
   "relational_id": "",
   "metadata": {

--- a/opensrp-reveal/src/main/assets/json.form/refapp_family_update.json
+++ b/opensrp-reveal/src/main/assets/json.form/refapp_family_update.json
@@ -1,6 +1,7 @@
 {
   "count": "2",
   "encounter_type": "Family Registration",
+  "form_version": "0.0.1",
   "entity_id": "",
   "relational_id": "",
   "metadata": {

--- a/opensrp-reveal/src/main/assets/json.form/refapp_larval_dipping_form.json
+++ b/opensrp-reveal/src/main/assets/json.form/refapp_larval_dipping_form.json
@@ -1,6 +1,7 @@
 {
   "count": "1",
   "encounter_type": "larval_dipping",
+  "form_version": "0.0.1",
   "entity_id": "",
   "metadata": {
     "start": {

--- a/opensrp-reveal/src/main/assets/json.form/refapp_mda_adherence.json
+++ b/opensrp-reveal/src/main/assets/json.form/refapp_mda_adherence.json
@@ -1,6 +1,7 @@
 {
   "count": "1",
   "encounter_type": "mda_adherence",
+  "form_version": "0.0.1",
   "entity_id": "",
   "metadata": {
     "start": {

--- a/opensrp-reveal/src/main/assets/json.form/refapp_mda_dispense.json
+++ b/opensrp-reveal/src/main/assets/json.form/refapp_mda_dispense.json
@@ -1,6 +1,7 @@
 {
   "count": "1",
   "encounter_type": "mda_dispense",
+  "form_version": "0.0.1",
   "entity_id": "",
   "metadata": {
     "start": {

--- a/opensrp-reveal/src/main/assets/json.form/refapp_mosquito_collection_form.json
+++ b/opensrp-reveal/src/main/assets/json.form/refapp_mosquito_collection_form.json
@@ -1,6 +1,7 @@
 {
   "count": "1",
   "encounter_type": "mosquito_collection",
+  "form_version": "0.0.1",
   "entity_id": "",
   "metadata": {
     "start": {

--- a/opensrp-reveal/src/main/assets/json.form/refapp_paot.json
+++ b/opensrp-reveal/src/main/assets/json.form/refapp_paot.json
@@ -1,6 +1,7 @@
 {
   "count": "1",
   "encounter_type": "PAOT",
+  "form_version": "0.0.1",
   "entity_id": "",
   "metadata": {
     "start": {

--- a/opensrp-reveal/src/main/assets/json.form/refapp_spray_form.json
+++ b/opensrp-reveal/src/main/assets/json.form/refapp_spray_form.json
@@ -1,6 +1,7 @@
 {
   "count": "1",
   "encounter_type": "Spray",
+  "form_version": "0.0.1",
   "entity_id": "",
   "metadata": {
     "start": {

--- a/opensrp-reveal/src/main/assets/json.form/spray_form.json
+++ b/opensrp-reveal/src/main/assets/json.form/spray_form.json
@@ -1,6 +1,7 @@
 {
   "count": "1",
   "encounter_type": "Spray",
+  "form_version": "0.0.1",
   "entity_id": "",
   "metadata": {
     "start": {

--- a/opensrp-reveal/src/main/assets/json.form/thailand_add_structure.json
+++ b/opensrp-reveal/src/main/assets/json.form/thailand_add_structure.json
@@ -1,6 +1,7 @@
 {
   "count": "1",
   "encounter_type": "Register_Structure",
+  "form_version": "0.0.1",
   "entity_id": "",
   "metadata": {
     "start": {

--- a/opensrp-reveal/src/main/assets/json.form/thailand_bednet_distribution.json
+++ b/opensrp-reveal/src/main/assets/json.form/thailand_bednet_distribution.json
@@ -1,6 +1,7 @@
 {
   "count": "1",
   "encounter_type": "bednet_distribution",
+  "form_version": "0.0.1",
   "entity_id": "",
   "metadata": {
     "start": {

--- a/opensrp-reveal/src/main/assets/json.form/thailand_behaviour_change_communication.json
+++ b/opensrp-reveal/src/main/assets/json.form/thailand_behaviour_change_communication.json
@@ -1,6 +1,7 @@
 {
   "count": "1",
   "encounter_type": "behaviour_change_communication",
+  "form_version": "0.0.1",
   "entity_id": "",
   "metadata": {
     "start": {

--- a/opensrp-reveal/src/main/assets/json.form/thailand_case_confirmation.json
+++ b/opensrp-reveal/src/main/assets/json.form/thailand_case_confirmation.json
@@ -1,6 +1,7 @@
 {
   "count": "1",
   "encounter_type": "case_confirmation",
+  "form_version": "0.0.1",
   "entity_id": "",
   "metadata": {
     "start": {

--- a/opensrp-reveal/src/main/assets/json.form/thailand_family_member_register.json
+++ b/opensrp-reveal/src/main/assets/json.form/thailand_family_member_register.json
@@ -1,6 +1,7 @@
 {
   "count": "1",
   "encounter_type": "Family Member Registration",
+  "form_version": "0.0.1",
   "entity_id": "",
   "relational_id": "",
   "metadata": {

--- a/opensrp-reveal/src/main/assets/json.form/thailand_family_register.json
+++ b/opensrp-reveal/src/main/assets/json.form/thailand_family_register.json
@@ -1,6 +1,7 @@
 {
   "count": "2",
   "encounter_type": "Family Registration",
+  "form_version": "0.0.1",
   "entity_id": "",
   "relational_id": "",
   "metadata": {

--- a/opensrp-reveal/src/main/assets/json.form/thailand_family_update.json
+++ b/opensrp-reveal/src/main/assets/json.form/thailand_family_update.json
@@ -1,6 +1,7 @@
 {
   "count": "2",
   "encounter_type": "Family Registration",
+  "form_version": "0.0.1",
   "entity_id": "",
   "relational_id": "",
   "metadata": {

--- a/opensrp-reveal/src/main/assets/json.form/thailand_larval_dipping_form.json
+++ b/opensrp-reveal/src/main/assets/json.form/thailand_larval_dipping_form.json
@@ -1,6 +1,7 @@
 {
   "count": "1",
   "encounter_type": "larval_dipping",
+  "form_version": "0.0.1",
   "entity_id": "",
   "metadata": {
     "start": {

--- a/opensrp-reveal/src/main/assets/json.form/thailand_mosquito_collection_form.json
+++ b/opensrp-reveal/src/main/assets/json.form/thailand_mosquito_collection_form.json
@@ -1,6 +1,7 @@
 {
   "count": "1",
   "encounter_type": "mosquito_collection",
+  "form_version": "0.0.1",
   "entity_id": "",
   "metadata": {
     "start": {

--- a/opensrp-reveal/src/main/assets/json.form/thailand_paot.json
+++ b/opensrp-reveal/src/main/assets/json.form/thailand_paot.json
@@ -1,6 +1,7 @@
 {
   "count": "1",
   "encounter_type": "PAOT",
+  "form_version": "0.0.1",
   "entity_id": "",
   "metadata": {
     "start": {

--- a/opensrp-reveal/src/main/assets/json.form/thailand_spray_form.json
+++ b/opensrp-reveal/src/main/assets/json.form/thailand_spray_form.json
@@ -1,6 +1,7 @@
 {
   "count": "1",
   "encounter_type": "Spray",
+  "form_version": "0.0.1",
   "entity_id": "",
   "metadata": {
     "start": {

--- a/opensrp-reveal/src/main/assets/json.form/zambia_cb_spray_area.json
+++ b/opensrp-reveal/src/main/assets/json.form/zambia_cb_spray_area.json
@@ -1,6 +1,7 @@
 {
   "count": "1",
   "encounter_type": "",
+  "form_version": "0.0.1",
   "entity_id": "",
   "metadata": {
     "start": {

--- a/opensrp-reveal/src/main/assets/json.form/zambia_daily_summary.json
+++ b/opensrp-reveal/src/main/assets/json.form/zambia_daily_summary.json
@@ -1,6 +1,7 @@
 {
   "count": "1",
   "encounter_type": "",
+  "form_version": "0.0.1",
   "entity_id": "",
   "metadata": {
     "start": {

--- a/opensrp-reveal/src/main/assets/json.form/zambia_family_member_register.json
+++ b/opensrp-reveal/src/main/assets/json.form/zambia_family_member_register.json
@@ -1,6 +1,7 @@
 {
   "count": "1",
   "encounter_type": "Family Member Registration",
+  "form_version": "0.0.1",
   "entity_id": "",
   "relational_id": "",
   "metadata": {

--- a/opensrp-reveal/src/main/assets/json.form/zambia_family_register.json
+++ b/opensrp-reveal/src/main/assets/json.form/zambia_family_register.json
@@ -1,6 +1,7 @@
 {
   "count": "2",
   "encounter_type": "Family Registration",
+  "form_version": "0.0.1",
   "entity_id": "",
   "relational_id": "",
   "metadata": {

--- a/opensrp-reveal/src/main/assets/json.form/zambia_family_update.json
+++ b/opensrp-reveal/src/main/assets/json.form/zambia_family_update.json
@@ -1,6 +1,7 @@
 {
   "count": "1",
   "encounter_type": "Family Registration",
+  "form_version": "0.0.1",
   "entity_id": "",
   "relational_id": "",
   "metadata": {

--- a/opensrp-reveal/src/main/assets/json.form/zambia_irs_field_officer.json
+++ b/opensrp-reveal/src/main/assets/json.form/zambia_irs_field_officer.json
@@ -1,6 +1,7 @@
 {
   "count": "1",
   "encounter_type": "",
+  "form_version": "0.0.1",
   "entity_id": "",
   "metadata": {
     "start": {

--- a/opensrp-reveal/src/main/assets/json.form/zambia_irs_sa_decision.json
+++ b/opensrp-reveal/src/main/assets/json.form/zambia_irs_sa_decision.json
@@ -1,6 +1,7 @@
 {
   "count": "1",
   "encounter_type": "",
+  "form_version": "0.0.1",
   "entity_id": "",
   "metadata": {
     "start": {

--- a/opensrp-reveal/src/main/assets/json.form/zambia_irs_verification.json
+++ b/opensrp-reveal/src/main/assets/json.form/zambia_irs_verification.json
@@ -1,6 +1,7 @@
 {
   "count": "1",
   "encounter_type": "irs_verification",
+  "form_version": "0.0.1",
   "entity_id": "",
   "metadata": {
     "start": {

--- a/opensrp-reveal/src/main/assets/json.form/zambia_mda_adherence.json
+++ b/opensrp-reveal/src/main/assets/json.form/zambia_mda_adherence.json
@@ -1,6 +1,7 @@
 {
   "count": "1",
   "encounter_type": "mda_adherence",
+  "form_version": "0.0.1",
   "entity_id": "",
   "metadata": {
     "start": {

--- a/opensrp-reveal/src/main/assets/json.form/zambia_mda_dispense.json
+++ b/opensrp-reveal/src/main/assets/json.form/zambia_mda_dispense.json
@@ -1,6 +1,7 @@
 {
   "count": "1",
   "encounter_type": "mda_dispense",
+  "form_version": "0.0.1",
   "entity_id": "",
   "metadata": {
     "start": {

--- a/opensrp-reveal/src/main/assets/json.form/zambia_mobilization_form.json
+++ b/opensrp-reveal/src/main/assets/json.form/zambia_mobilization_form.json
@@ -1,6 +1,7 @@
 {
   "count": "1",
   "encounter_type": "",
+  "form_version": "0.0.1",
   "entity_id": "",
   "metadata": {
     "start": {

--- a/opensrp-reveal/src/main/assets/json.form/zambia_spray_form.json
+++ b/opensrp-reveal/src/main/assets/json.form/zambia_spray_form.json
@@ -1,6 +1,7 @@
 {
   "count": "1",
   "encounter_type": "Spray",
+  "form_version": "0.0.1",
   "entity_id": "",
   "metadata": {
     "start": {

--- a/opensrp-reveal/src/main/assets/json.form/zambia_team_leader_dos.json
+++ b/opensrp-reveal/src/main/assets/json.form/zambia_team_leader_dos.json
@@ -1,6 +1,7 @@
 {
   "count": "1",
   "encounter_type": "",
+  "form_version": "0.0.1",
   "entity_id": "",
   "metadata": {
     "start": {

--- a/opensrp-reveal/src/main/assets/json.form/zambia_verification_form.json
+++ b/opensrp-reveal/src/main/assets/json.form/zambia_verification_form.json
@@ -1,6 +1,7 @@
 {
   "count": "1",
   "encounter_type": "",
+  "form_version": "0.0.1",
   "entity_id": "",
   "metadata": {
     "start": {


### PR DESCRIPTION
The `form_version` in the forms is used to track which form created a specific event.
Form configuration makes this dynamic and always populates it with the form version from the server in case the client app is using a form from the server.

We need to update the static json forms with the initial form version.