### PR TITLE
Remove long hold that results in 'inactive' grey structure for Zambia build

### DIFF
--- a/opensrp-reveal/src/main/java/org/smartregister/reveal/presenter/ListTaskPresenter.java
+++ b/opensrp-reveal/src/main/java/org/smartregister/reveal/presenter/ListTaskPresenter.java
@@ -288,7 +288,9 @@ public class ListTaskPresenter implements ListTaskContract.Presenter, PasswordRe
         listTaskView.closeAllCardViews();
         listTaskView.displaySelectedFeature(feature, clickedPoint);
         if (isLongclick) {
+            if (BuildConfig.BUILD_COUNTRY != Country.ZAMBIA) {
                 onFeatureSelectedByLongClick(feature);
+            }
         } else {
             onFeatureSelectedByNormalClick(feature);
         }


### PR DESCRIPTION
Resolves #926 