### PR TITLE
Skip marking events as synced if P2P  processing is running

### DIFF
--- a/opensrp-reveal/src/main/java/org/smartregister/reveal/sync/RevealClientProcessor.java
+++ b/opensrp-reveal/src/main/java/org/smartregister/reveal/sync/RevealClientProcessor.java
@@ -8,6 +8,7 @@ import androidx.localbroadcastmanager.content.LocalBroadcastManager;
 
 import org.apache.commons.lang3.StringUtils;
 import org.joda.time.DateTime;
+import org.smartregister.CoreLibrary;
 import org.smartregister.domain.Client;
 import org.smartregister.domain.Event;
 import org.smartregister.domain.Location;
@@ -277,7 +278,7 @@ public class RevealClientProcessor extends ClientProcessorForJava {
             if (localEvents && BaseRepository.TYPE_Synced.equals(task.getSyncStatus())) {
                 task.setSyncStatus(BaseRepository.TYPE_Unsynced);
                 revealApplication.setSynced(false);
-            } else if (!localEvents && event.getServerVersion() != 0) {
+            } else if (!localEvents && event.getServerVersion() != 0 && !CoreLibrary.getInstance().isPeerToPeerProcessing()) {
                 // for events synced from server and task exists mark events as being fully synced
                 eventClientRepository.markEventAsSynced(event.getFormSubmissionId());
             }

--- a/opensrp-reveal/src/test/java/org/smartregister/reveal/sync/RevealClientProcessorPowerMockTest.java
+++ b/opensrp-reveal/src/test/java/org/smartregister/reveal/sync/RevealClientProcessorPowerMockTest.java
@@ -10,6 +10,7 @@ import org.powermock.api.mockito.PowerMockito;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 import org.powermock.reflect.Whitebox;
+import org.smartregister.CoreLibrary;
 import org.smartregister.domain.Location;
 import org.smartregister.domain.LocationProperty;
 import org.smartregister.domain.Task;
@@ -58,7 +59,7 @@ import static org.smartregister.reveal.util.Constants.TASK_RESET_EVENT;
  * @author Vincent Karuri
  */
 @RunWith(PowerMockRunner.class)
-@PrepareForTest({RevealClientProcessor.class, Utils.class, PreferencesUtil.class, RevealApplication.class})
+@PrepareForTest({RevealClientProcessor.class, Utils.class, PreferencesUtil.class, RevealApplication.class, CoreLibrary.class})
 public class RevealClientProcessorPowerMockTest {
 
     private RevealClientProcessor clientProcessor;
@@ -166,6 +167,10 @@ public class RevealClientProcessorPowerMockTest {
     @Test
     public void testUpdateTaskShouldMarkEventAsSynced() throws Exception {
         mockRepositories();
+        mockStatic(CoreLibrary.class);
+        CoreLibrary coreLibrary = mock(CoreLibrary.class);
+        PowerMockito.when(coreLibrary.isPeerToPeerProcessing()).thenReturn(false);
+        PowerMockito.when(CoreLibrary.getInstance()).thenReturn(coreLibrary);
         event.setServerVersion(System.currentTimeMillis());
 
         Whitebox.invokeMethod(clientProcessor, "updateTask", event, false);


### PR DESCRIPTION
Resolves #1124 and Resolves #1136 