### PR TITLE
allow sync complete toasts to display one afteranother when syncstart wasn't triggered

### DIFF
--- a/opensrp-reveal/src/main/java/org/smartregister/reveal/util/Constants.java
+++ b/opensrp-reveal/src/main/java/org/smartregister/reveal/util/Constants.java
@@ -71,7 +71,7 @@ public interface Constants {
     String ACTIONS = "actions";
     String THAILAND_SYNC_INTERVAL = "720";
 
-    int SYNC_BACK_OFF_DELAY = 5000;
+    int SYNC_BACK_OFF_DELAY = 8000;
 
     interface CONFIGURATION {
         String LOGIN = "login";

--- a/opensrp-reveal/src/main/java/org/smartregister/reveal/view/ListTasksActivity.java
+++ b/opensrp-reveal/src/main/java/org/smartregister/reveal/view/ListTasksActivity.java
@@ -859,7 +859,7 @@ public class ListTasksActivity extends BaseMapActivity implements ListTaskContra
         if (FetchStatus.fetched.equals(fetchStatus)) {
             return;
         }
-        if (completedToastShown) return;
+        if (startedToastShown && completedToastShown) return;
         //To cover against consecutive sync starts firing, turn the flag off with delay
         new Handler().postDelayed(() -> startedToastShown = false, SYNC_BACK_OFF_DELAY);
         boolean isNetworkAvailable = NetworkUtils.isNetworkAvailable();

--- a/opensrp-reveal/src/test/java/org/smartregister/reveal/view/ListTasksActivityTest.java
+++ b/opensrp-reveal/src/test/java/org/smartregister/reveal/view/ListTasksActivityTest.java
@@ -737,6 +737,7 @@ public class ListTasksActivityTest extends BaseUnitTest {
     @Test
     public void testOnConsecutiveSyncCompletedToastIsShownOnce() {
         init(listTasksActivity);
+        Whitebox.setInternalState(listTasksActivity, "startedToastShown", true);
         listTasksActivity.onSyncInProgress(FetchStatus.nothingFetched);
         listTasksActivity.onSyncInProgress(FetchStatus.nothingFetched);
         assertEquals(1, ShadowToast.shownToastCount());


### PR DESCRIPTION
resolved #1395 
