### PR TITLE
update client-family to v2.0.4-SNAPSHOT

### DIFF
--- a/opensrp-reveal/build.gradle
+++ b/opensrp-reveal/build.gradle
@@ -164,7 +164,9 @@ android {
         }
 
         debug {
-            resValue "string", 'opensrp_base_url', '"https://reveal-stage.smartregister.org/opensrp/"'
+            resValue "string", 'opensrp_base_url', '"https://reveal-th-preview.smartregister.org/opensrp/"'
+//            resValue "string", 'opensrp_base_url', '"https://reveal-stage.smartregister.org/opensrp/"'
+//            resValue "string", 'opensrp_base_url', '"http://10.0.2.2:8080/opensrp/"'
             buildConfigField "Integer", "DATABASE_VERSION", '14'
             buildConfigField "int", "OPENMRS_UNIQUE_ID_INITIAL_BATCH_SIZE", '250'
             buildConfigField "int", "OPENMRS_UNIQUE_ID_BATCH_SIZE", '100'
@@ -242,7 +244,7 @@ dependencies {
         exclude group: 'com.android.support', module: 'appcompat-v7'
     }
 
-    implementation('org.smartregister:opensrp-client-family:2.0.4-FORM-CONFIG-RULES-FIX-SNAPSHOT@aar') {
+    implementation('org.smartregister:opensrp-client-family:2.0.4-SNAPSHOT@aar') {
         transitive = true
         exclude group: 'org.smartregister', module: 'opensrp-client-core'
         exclude group: 'org.smartregister', module: 'opensrp-client-native-form'

--- a/opensrp-reveal/build.gradle
+++ b/opensrp-reveal/build.gradle
@@ -164,9 +164,7 @@ android {
         }
 
         debug {
-            resValue "string", 'opensrp_base_url', '"https://reveal-th-preview.smartregister.org/opensrp/"'
-//            resValue "string", 'opensrp_base_url', '"https://reveal-stage.smartregister.org/opensrp/"'
-//            resValue "string", 'opensrp_base_url', '"http://10.0.2.2:8080/opensrp/"'
+            resValue "string", 'opensrp_base_url', '"https://reveal-stage.smartregister.org/opensrp/"'
             buildConfigField "Integer", "DATABASE_VERSION", '14'
             buildConfigField "int", "OPENMRS_UNIQUE_ID_INITIAL_BATCH_SIZE", '250'
             buildConfigField "int", "OPENMRS_UNIQUE_ID_BATCH_SIZE", '100'


### PR DESCRIPTION
to fix crash
https://console.firebase.google.com/u/0/project/opensrp-production/crashlytics/app/android:org.smartregister.reveal/issues/93d020026b2886784e6e8b612dadb7f2?time=last-hour&sessionEventKey=6110F53D00A40001522AC02BC2421007_1572842833036191670

Resolves #1504 

- [x]  Remove github custom repository used for testing